### PR TITLE
Include PID, timestamp, loglevel and uniq_id on every line of logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Provide log formatter for Grape API. Logged data now contains PID, Time, Path, P
 
 ## Example
 ```bash
-[2016-07-01 15:31:42 +0200] INFO -- POST 200  /api/v1/publish_product_review
-Params: {"lead_content_id":"4266a24e-ec1e-4818-9c09-ceb269c693a3","content_type":"product_reviews"}
-PID: 30896 | IP: 127.0.0.1 | Total: 4.28 DB: 0.0 View: 4.28
+#                            Request ID, PID
+[2016-07-04 09:37:42 +0100] <289cd741fe:#6760> INFO -- POST 200  /api/v1/locks
+[2016-07-04 09:37:42 +0100] <289cd741fe:#6760> INFO -- Params: {"content_id":"68e69712-2681-481d-8b36-904a99bb6ee1"}
+[2016-07-04 09:37:42 +0100] <289cd741fe:#6760> INFO -- IP: 127.0.0.1 | Total: 108.18 DB: 0.0 View: 108.18
 ```
 
 ## Installation

--- a/grape_log_formatter.gemspec
+++ b/grape_log_formatter.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry"
 end

--- a/lib/grape_log_formatter/version.rb
+++ b/lib/grape_log_formatter/version.rb
@@ -1,3 +1,3 @@
 module GrapeLogFormatter
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/grape_log_formatter/basic_spec.rb
+++ b/spec/grape_log_formatter/basic_spec.rb
@@ -6,10 +6,15 @@ describe GrapeLogFormatter::Basic do
 
   let(:result) { GrapeLogFormatter::Basic.new.call(severity, time, nil, data) }
   let(:pid) { $PROCESS_ID }
+  let(:uniq_id) { "a345dv" }
   let(:exception) do
     e = StandardError.new("Application failed")
     e.set_backtrace(%w(file_1 file_2))
     e
+  end
+
+  before do
+    allow(SecureRandom).to receive(:hex) { uniq_id }
   end
 
   context "data is a string" do
@@ -17,7 +22,7 @@ describe GrapeLogFormatter::Basic do
 
     it "contain time, severity and data string" do
       expect(result).to eq <<-STR
-[2016-05-06 18:20:00 +0200] INFO -- Warning message
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Warning message
 
 STR
     end
@@ -28,7 +33,7 @@ STR
 
     it "contain time, severity and exception title and backtrace" do
       expect(result).to eq <<-STR
-[2016-05-06 18:20:00 +0200] INFO -- Application failed
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Application failed
 \tfile_1
 \tfile_2
 
@@ -52,9 +57,9 @@ STR
 
       it "contain time, severity, method, status, path, params, pid, ip and time" do
         expect(result).to eq <<-STR
-[2016-05-06 18:20:00 +0200] INFO -- POST 200  /api/v1/locks
-Params: {"content_id":"150d33f4-d9a7-4e21-b425-067c638d1ffe"}
-PID: #{pid} | IP: 127.0.0.1 | Total: 18.18 DB: 0.0 View: 18.18
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- POST 200  /api/v1/locks
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Params: {"content_id":"150d33f4-d9a7-4e21-b425-067c638d1ffe"}
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- IP: 127.0.0.1 | Total: 18.18 DB: 0.0 View: 18.18
 
         STR
       end
@@ -71,9 +76,9 @@ PID: #{pid} | IP: 127.0.0.1 | Total: 18.18 DB: 0.0 View: 18.18
 
       it "contain time, severity, pid, exception title, backtrace" do
         expect(result).to eq <<-STR
-[2016-05-06 18:20:00 +0200] INFO -- rescued_exception
-PID: #{pid} | IP: - | Total: - DB: - View: -
-Application failed
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- rescued_exception
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- IP: - | Total: - DB: - View: -
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Application failed
 \tfile_1
 \tfile_2
 
@@ -99,10 +104,10 @@ Application failed
 
       it "contain time, severity, pid, exception title, backtrace" do
         expect(result).to eq <<-STR
-[2016-05-06 18:20:00 +0200] INFO -- rescued_exception /api/v1/locks/cce8e905
-Params: {"id":"cce8e905"}
-PID: #{pid} | IP: 127.0.0.1 | Total: - DB: - View: -
-Application failed
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- rescued_exception /api/v1/locks/cce8e905
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Params: {"id":"cce8e905"}
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- IP: 127.0.0.1 | Total: - DB: - View: -
+[2016-05-06 18:20:00 +0200] <a345dv:##{pid}> INFO -- Application failed
 \tfile_1
 \tfile_2
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "pry"
 require "grape_log_formatter"


### PR DESCRIPTION
- issue: #1 
- add pid, uniq_id, timestamp and loglevel to each line of log so it is much easier to grep for specific log message when interleaving log lines happen
